### PR TITLE
Fix night detection

### DIFF
--- a/src/Http/Controllers/WorldClockController.php
+++ b/src/Http/Controllers/WorldClockController.php
@@ -12,12 +12,9 @@ class WorldClockController
             $request->timeFormat = 'h:i:s';
         }
         $times = [];
-        $night = true;
         foreach ($request->timezones as $timezone){
             $time = Carbon::now($timezone);
-            if ($time->format('H') < 17) {
-                $night = false;
-            }
+            $night = (int) $time->format('H') > 17;
             $name = explode('/',$time->getTimezone()->getName())[1];
             $name = str_replace('_',' ',$name);
             array_push($times,[


### PR DESCRIPTION
There is a bug in night detection: `$night` if override inside a loop and new value is used as default for all the reset iterations.